### PR TITLE
Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # vcf_haemonc_annotation_from_inca_creator
 Development and testing of annotation VCF for haemonc annotation from Inca CSV
 Can be run like so:
+
 ```python3 create_vcf_from_inca_csv.py --filename updated_250130.csv```
+
 or like so:
+
 ```python3 create_vcf_from_inca_csv.py -f updated_250130.csv```
 

--- a/README.md
+++ b/README.md
@@ -2,5 +2,6 @@
 Development and testing of annotation VCF for haemonc annotation from Inca CSV
 Can be run like so:
 ```python3 create_vcf_from_inca_csv.py --filename updated_250130.csv```
+or like so:
 ```python3 create_vcf_from_inca_csv.py -f updated_250130.csv```
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # vcf_haemonc_annotation_from_inca_creator
 Development and testing of annotation VCF for haemonc annotation from Inca CSV
+Can be run like so:
+```python3 create_vcf_from_inca_csv.py --filename updated_250130.csv```

--- a/README.md
+++ b/README.md
@@ -2,3 +2,5 @@
 Development and testing of annotation VCF for haemonc annotation from Inca CSV
 Can be run like so:
 ```python3 create_vcf_from_inca_csv.py --filename updated_250130.csv```
+```python3 create_vcf_from_inca_csv.py -f updated_250130.csv```
+

--- a/create_vcf_from_inca_csv.py
+++ b/create_vcf_from_inca_csv.py
@@ -1,16 +1,17 @@
 import pandas as pd
 import argparse
+import subprocess
 
-# Load CSV into a DataFrame with argparse
+# Load CSV name from command line with argparse
 parser = argparse.ArgumentParser()
 parser.add_argument('-filename', '--filename')
-
 args = parser.parse_args()
 
-# Ensure 'date_last_evaluated' is parsed as datetime
-df = pd.read_csv(args.filename, parse_dates=['date_last_evaluated'])
+# Load CSV from Inca into a DataFrame 
+# Ensure 'date_last_evaluated' is parsed as datetime and reduce the risk of type inference errors
+df = pd.read_csv(args.filename, parse_dates=['date_last_evaluated'], low_memory=False) 
 
-# Remove any spaces and substitute with _
+# Remove spaces and clean fields
 df['oncogenicity_classification'] = df['oncogenicity_classification'].str.replace(' ', '_')
 df['chromosome'] = df['chromosome'].str.replace(' ', '')
 
@@ -21,13 +22,14 @@ df_sorted = df.sort_values(
 )
 
 # Flag the latest record for each group
-df_sorted['is_latest'] = df_sorted.gry(['hgvsc']).cumcount() == 0
+df_sorted['is_latest'] = df_sorted.groupby(['hgvsc']).cumcount() == 0
 
 # Separate the latest records
 latest_df = df_sorted[df_sorted['is_latest']].drop(columns='is_latest')
 
 # Separate the other records
 other_df = df_sorted[~df_sorted['is_latest']].drop(columns='is_latest')
+
 
 # Aggregate other oncogenicity classifications with counts
 def format_oncogenicity_counts(x):
@@ -40,6 +42,7 @@ grouped_other_oncogenicity = other_df.groupby(['hgvsc']).agg({
     'oncogenicity_classification': format_oncogenicity_counts
 }).rename(columns={'oncogenicity_classification': 'Other_Classifications'}).reset_index()
 
+
 # Merge the latest records with aggregated other classifications
 merged_df = pd.merge(
     latest_df,
@@ -47,17 +50,46 @@ merged_df = pd.merge(
     on=['hgvsc'],
     how='left'
 )
-print(merged_df.shape)
+
+
+# Define contigs
+contigs = """##contig=<ID=1,length=248956422,assembly=hg38>
+##contig=<ID=2,length=242193529,assembly=hg38>
+##contig=<ID=3,length=198295559,assembly=hg38>
+##contig=<ID=4,length=190214555,assembly=hg38>
+##contig=<ID=5,length=181538259,assembly=hg38>
+##contig=<ID=6,length=170805979,assembly=hg38>
+##contig=<ID=7,length=159345973,assembly=hg38>
+##contig=<ID=8,length=145138636,assembly=hg38>
+##contig=<ID=9,length=138394717,assembly=hg38>
+##contig=<ID=10,length=133797422,assembly=hg38>
+##contig=<ID=11,length=135086622,assembly=hg38>
+##contig=<ID=12,length=133275309,assembly=hg38>
+##contig=<ID=13,length=114364328,assembly=hg38>
+##contig=<ID=14,length=107043718,assembly=hg38>
+##contig=<ID=15,length=101991189,assembly=hg38>
+##contig=<ID=16,length=90338345,assembly=hg38>
+##contig=<ID=17,length=83257441,assembly=hg38>
+##contig=<ID=18,length=80373285,assembly=hg38>
+##contig=<ID=19,length=58617616,assembly=hg38>
+##contig=<ID=20,length=64444167,assembly=hg38>
+##contig=<ID=21,length=46709983,assembly=hg38>
+##contig=<ID=22,length=50818468,assembly=hg38>
+##contig=<ID=X,length=156040895,assembly=hg38>
+##contig=<ID=Y,length=57227415,assembly=hg38>
+"""
 
 # Write the VCF file
 with open('output.vcf', 'w') as vcf_file:
-    # Write VCF header LC = latest classification
+    # Write VCF header
     vcf_file.write("##fileformat=VCFv4.2\n")
     vcf_file.write("##reference=GRCh38\n")
-    vcf_file.write('##INFO=<ID=EG_LC,Number=1,Type=String,Description="Oncogenicity classification of the variant">\n')
+    vcf_file.write(contigs)  # Write contigs
+    vcf_file.write('##INFO=<ID=EG_LC,Number=1,Type=String,Description="Oncogenicity classification of the latest variant">\n')
     vcf_file.write('##INFO=<ID=EG_LCD,Number=1,Type=String,Description="Date of latest classification evaluation">\n')
     vcf_file.write('##INFO=<ID=EG_LCS,Number=1,Type=String,Description="Specimen ID of the latest classification">\n')
     vcf_file.write('##INFO=<ID=EG_OC,Number=.,Type=String,Description="Other Classifications with counts">\n')
+    vcf_file.write('##INFO=<ID=EG_HGVS,Number=1,Type=String,Description="HGVS notation of the variant">\n')
     vcf_file.write("#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n")
 
     # Write VCF data
@@ -71,11 +103,16 @@ with open('output.vcf', 'w') as vcf_file:
             f"EG_LC={row['oncogenicity_classification']};"
             f"EG_LCD={row['date_last_evaluated'].strftime('%Y-%m-%d')};"
             f"EG_LCS={row['specimen_id']};"
-            f"EG_OC={other_oncogenicity}"
+            f"EG_OC={other_oncogenicity};"
+            f"EG_HGVS={row['hgvsc']}"
         )
         vcf_file.write(
-            f"{row['chromosome']}\t{row['start']}\t{row['hgvsc']}\t"
+            f"{row['chromosome']}\t{row['start']}\t{row['local_id']}\t"
             f"{row['reference_allele']}\t{row['alternate_allele']}\t.\t.\t{info_field}\n"
         )
 
-print("VCF file created as 'output.vcf'")
+## Sort VCF
+with open("sorted.vcf", "w") as sorted_vcf:
+    subprocess.run(["vcf-sort", "output.vcf"], stdout=sorted_vcf, check=True)
+
+print("VCF file created as 'sorted.vcf'")

--- a/create_vcf_from_inca_csv.py
+++ b/create_vcf_from_inca_csv.py
@@ -1,0 +1,81 @@
+import pandas as pd
+import argparse
+
+# Load CSV into a DataFrame with argparse
+parser = argparse.ArgumentParser()
+parser.add_argument('-filename', '--filename')
+
+args = parser.parse_args()
+
+# Ensure 'date_last_evaluated' is parsed as datetime
+df = pd.read_csv(args.filename, parse_dates=['date_last_evaluated'])
+
+# Remove any spaces and substitute with _
+df['oncogenicity_classification'] = df['oncogenicity_classification'].str.replace(' ', '_')
+df['chromosome'] = df['chromosome'].str.replace(' ', '')
+
+# Sort and flag the latest variant records
+df_sorted = df.sort_values(
+    by=['hgvsc', 'date_last_evaluated'],
+    ascending=[True, False]
+)
+
+# Flag the latest record for each group
+df_sorted['is_latest'] = df_sorted.gry(['hgvsc']).cumcount() == 0
+
+# Separate the latest records
+latest_df = df_sorted[df_sorted['is_latest']].drop(columns='is_latest')
+
+# Separate the other records
+other_df = df_sorted[~df_sorted['is_latest']].drop(columns='is_latest')
+
+# Aggregate other oncogenicity classifications with counts
+def format_oncogenicity_counts(x):
+    counts = x.value_counts()
+    formatted_counts = [f"{cls}({count})" for cls, count in counts.items()]
+    return "|".join(formatted_counts)
+
+
+grouped_other_oncogenicity = other_df.groupby(['hgvsc']).agg({
+    'oncogenicity_classification': format_oncogenicity_counts
+}).rename(columns={'oncogenicity_classification': 'Other_Classifications'}).reset_index()
+
+# Merge the latest records with aggregated other classifications
+merged_df = pd.merge(
+    latest_df,
+    grouped_other_oncogenicity,
+    on=['hgvsc'],
+    how='left'
+)
+print(merged_df.shape)
+
+# Write the VCF file
+with open('output.vcf', 'w') as vcf_file:
+    # Write VCF header LC = latest classification
+    vcf_file.write("##fileformat=VCFv4.2\n")
+    vcf_file.write("##reference=GRCh38\n")
+    vcf_file.write('##INFO=<ID=EG_LC,Number=1,Type=String,Description="Oncogenicity classification of the variant">\n')
+    vcf_file.write('##INFO=<ID=EG_LCD,Number=1,Type=String,Description="Date of latest classification evaluation">\n')
+    vcf_file.write('##INFO=<ID=EG_LCS,Number=1,Type=String,Description="Specimen ID of the latest classification">\n')
+    vcf_file.write('##INFO=<ID=EG_OC,Number=.,Type=String,Description="Other Classifications with counts">\n')
+    vcf_file.write("#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n")
+
+    # Write VCF data
+    for _, row in merged_df.iterrows():
+        # Handle possible missing Other_Classifications
+        other_oncogenicity = (
+            row['Other_Classifications']
+            if pd.notnull(row['Other_Classifications']) else '.'
+        )
+        info_field = (
+            f"EG_LC={row['oncogenicity_classification']};"
+            f"EG_LCD={row['date_last_evaluated'].strftime('%Y-%m-%d')};"
+            f"EG_LCS={row['specimen_id']};"
+            f"EG_OC={other_oncogenicity}"
+        )
+        vcf_file.write(
+            f"{row['chromosome']}\t{row['start']}\t{row['hgvsc']}\t"
+            f"{row['reference_allele']}\t{row['alternate_allele']}\t.\t.\t{info_field}\n"
+        )
+
+print("VCF file created as 'output.vcf'")

--- a/create_vcf_from_inca_csv.py
+++ b/create_vcf_from_inca_csv.py
@@ -26,8 +26,25 @@ parser = argparse.ArgumentParser()
 parser.add_argument('-f', '--filename', required=True, help="Input CSV file containing variant data")
 args = parser.parse_args()
 
-# Load CSV into a DataFrame
-df = pd.read_csv(args.filename, parse_dates=['date_last_evaluated'], low_memory=False)
+# Load CSV into a DataFrame with error handling
+try:
+    df = pd.read_csv(
+        args.filename,
+        parse_dates=['date_last_evaluated'],
+        low_memory=False
+    )
+    required_columns = [
+        'date_last_evaluated',
+        'oncogenicity_classification',
+        'chromosome',
+        'hgvsc'
+    ]
+    missing_columns = [col for col in required_columns if col not in df.columns]
+    if missing_columns:
+        raise ValueError(f"Missing required columns: {', '.join(missing_columns)}")
+except Exception as e:
+    print(f"Error loading CSV file: {e}")
+    exit(1)
 
 # Clean and preprocess fields
 df['oncogenicity_classification'] = df['oncogenicity_classification'].str.replace(' ', '_')

--- a/create_vcf_from_inca_csv.py
+++ b/create_vcf_from_inca_csv.py
@@ -2,144 +2,116 @@ import pandas as pd
 import argparse
 import datetime
 
-
-
-# Load CSV name from command line with argparse
-parser = argparse.ArgumentParser()
-parser.add_argument('-f', '--filename')
-args = parser.parse_args()
-
-# Load CSV from Inca into a DataFrame 
-# Ensure 'date_last_evaluated' is parsed as datetime and reduce the risk of type inference errors
-df = pd.read_csv(args.filename, parse_dates=['date_last_evaluated'], low_memory=False) 
-
-
-
-# Generate a timestamp
-timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
-
-# Create a descriptive filename
-output_filename = f"haemonc_annotation_VCF_{timestamp}.vcf"
-
-
-# Remove spaces and clean fields
-df['oncogenicity_classification'] = df['oncogenicity_classification'].str.replace(' ', '_')
-df['chromosome'] = df['chromosome'].str.replace(' ', '')
-
-# Sort and flag the latest variant records
-df_sorted = df.sort_values(
-    by=['hgvsc', 'date_last_evaluated'],
-    ascending=[True, False]
-)
-
-# Flag the latest record for each group
-df_sorted['is_latest'] = df_sorted.groupby(['hgvsc']).cumcount() == 0
-
-# Separate the latest records
-latest_df = df_sorted[df_sorted['is_latest']].drop(columns='is_latest')
-
-# Separate the other records
-other_df = df_sorted[~df_sorted['is_latest']].drop(columns='is_latest')
-
-
-# Aggregate other oncogenicity classifications with counts
-def format_oncogenicity_counts(classifications):
+# Function to format total classifications with counts
+def format_total_classifications(classifications):
     """
-    Format oncogenicity classifications with their counts.
-    This function takes a series of oncogenicity classifications,
-    counts the occurances of each classification formats them as:
-    classification(count)|other_classification(count)
-    Args:
-        classifications: Series of oncogenicity classifications.
-    Returns:
-        Formatted string of classification with counts, joined
-        by the '|' character
+    Counts all classifications, including the latest classification.
+    Returns classifications in the format: classification(count)|classification(count)
     """
     counts = classifications.value_counts()
     formatted_counts = [f"{classification}({count})" for classification, count in counts.items()]
     return "|".join(formatted_counts)
 
+# Function to aggregate HGVS annotations
+def aggregate_hgvs(hgvs_series):
+    """
+    Aggregates all unique HGVS
+    Returns them joined by |
+    """
+    unique_hgvs = hgvs_series.dropna().unique()
+    return "|".join(unique_hgvs)
 
-grouped_other_oncogenicity = other_df.groupby(['hgvsc']).agg({
-    'oncogenicity_classification': format_oncogenicity_counts
-}).rename(columns={'oncogenicity_classification': 'Other_Classifications'}).reset_index()
+# Load CSV name from command line with argparse
+parser = argparse.ArgumentParser()
+parser.add_argument('-f', '--filename', required=True, help="Input CSV file containing variant data")
+args = parser.parse_args()
+
+# Load CSV into a DataFrame
+df = pd.read_csv(args.filename, parse_dates=['date_last_evaluated'], low_memory=False)
+
+# Clean and preprocess fields
+df['oncogenicity_classification'] = df['oncogenicity_classification'].str.replace(' ', '_')
+df['chromosome'] = df['chromosome'].str.replace(' ', '')
+
+# Ensure 'date_last_evaluated' is not missing
+df = df.dropna(subset=['date_last_evaluated'])
+
+# Group by unique variant identifiers
+grouped = df.groupby(['chromosome', 'start', 'reference_allele', 'alternate_allele'])
+
+# Function to get the latest entry based on 'date_last_evaluated'
+def get_latest_entry(sub_df):
+    """
+    Function that returns the latest evaluated date
+    by using idx.max()
+    """
+    latest_idx = sub_df['date_last_evaluated'].idxmax()
+    latest_entry = sub_df.loc[latest_idx]
+    return latest_entry
+
+# Aggregate data for each unique variant
+aggregated_data = []
+for _, group in grouped:
+    latest_entry = get_latest_entry(group)
+    latest_classification = latest_entry['oncogenicity_classification']
+    latest_date = latest_entry['date_last_evaluated']
+    latest_sample_id = latest_entry['specimen_id']
+    hgvs = aggregate_hgvs(group['hgvsc'])
+    total_classifications = format_total_classifications(group['oncogenicity_classification'])  # Now includes all classifications
+    
+    aggregated_data.append({
+        'chromosome': latest_entry['chromosome'],
+        'start': latest_entry['start'],
+        'reference_allele': latest_entry['reference_allele'],
+        'alternate_allele': latest_entry['alternate_allele'],
+        'latest_classification': latest_classification,
+        'latest_date': latest_date,
+        'latest_sample_id': latest_sample_id,
+        'total_classifications': total_classifications,  # Replacing OC with TC
+        'hgvs': hgvs
+    })
+
+aggregated_df = pd.DataFrame(aggregated_data)
+
+# Generate a timestamp for the output filename
+timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+output_filename = f"haemonc_annotation_VCF_{timestamp}.vcf"
 
 
-# Merge the latest records with aggregated other classifications
-merged_df = pd.merge(
-    latest_df,
-    grouped_other_oncogenicity,
-    on=['hgvsc'],
-    how='left'
-)
-
-# Sort the merged DataFrame
+# Sort the merged DataFrame by Chromosome and start position:
 # Define chromosome order: numeric first, then X and Y
 chromosome_order = [str(i) for i in range(1, 23)] + ['X', 'Y']
 # Convert 'chromosome' column to categorical type with specified order
-merged_df['chromosome'] = pd.Categorical(merged_df['chromosome'], categories=chromosome_order, ordered=True)
+aggregated_df['chromosome'] = pd.Categorical(aggregated_df['chromosome'], categories=chromosome_order, ordered=True)
 # Sort first by chromosome order, then by start position
-merged_df = merged_df.sort_values(by=['chromosome', 'start'])
+aggregated_df = aggregated_df.sort_values(by=['chromosome', 'start'])
 
-
-# Define contigs
-contigs = """##contig=<ID=1,length=248956422,assembly=hg38>
-##contig=<ID=2,length=242193529,assembly=hg38>
-##contig=<ID=3,length=198295559,assembly=hg38>
-##contig=<ID=4,length=190214555,assembly=hg38>
-##contig=<ID=5,length=181538259,assembly=hg38>
-##contig=<ID=6,length=170805979,assembly=hg38>
-##contig=<ID=7,length=159345973,assembly=hg38>
-##contig=<ID=8,length=145138636,assembly=hg38>
-##contig=<ID=9,length=138394717,assembly=hg38>
-##contig=<ID=10,length=133797422,assembly=hg38>
-##contig=<ID=11,length=135086622,assembly=hg38>
-##contig=<ID=12,length=133275309,assembly=hg38>
-##contig=<ID=13,length=114364328,assembly=hg38>
-##contig=<ID=14,length=107043718,assembly=hg38>
-##contig=<ID=15,length=101991189,assembly=hg38>
-##contig=<ID=16,length=90338345,assembly=hg38>
-##contig=<ID=17,length=83257441,assembly=hg38>
-##contig=<ID=18,length=80373285,assembly=hg38>
-##contig=<ID=19,length=58617616,assembly=hg38>
-##contig=<ID=20,length=64444167,assembly=hg38>
-##contig=<ID=21,length=46709983,assembly=hg38>
-##contig=<ID=22,length=50818468,assembly=hg38>
-##contig=<ID=X,length=156040895,assembly=hg38>
-##contig=<ID=Y,length=57227415,assembly=hg38>
-"""
 
 # Write the VCF file
 with open(output_filename, 'w') as vcf_file:
     # Write VCF header
     vcf_file.write("##fileformat=VCFv4.2\n")
+    vcf_file.write("##source=EG\n")
     vcf_file.write("##reference=GRCh38\n")
-    vcf_file.write(contigs)  # Write contigs
-    vcf_file.write('##INFO=<ID=EG_LC,Number=1,Type=String,Description="Oncogenicity classification of the latest variant">\n')
-    vcf_file.write('##INFO=<ID=EG_LCD,Number=1,Type=String,Description="Date of latest classification evaluation">\n')
-    vcf_file.write('##INFO=<ID=EG_LCS,Number=1,Type=String,Description="Specimen ID of the latest classification">\n')
-    vcf_file.write('##INFO=<ID=EG_OC,Number=.,Type=String,Description="Other Classifications with counts">\n')
-    vcf_file.write('##INFO=<ID=EG_HGVS,Number=1,Type=String,Description="HGVS notation of the variant">\n')
+    vcf_file.write('##INFO=<ID=LC,Number=1,Type=String,Description="Latest classification">\n')
+    vcf_file.write('##INFO=<ID=LCD,Number=1,Type=String,Description="Latest classification date">\n')
+    vcf_file.write('##INFO=<ID=LCS,Number=1,Type=String,Description="Latest classification sample ID">\n')
+    vcf_file.write('##INFO=<ID=TC,Number=.,Type=String,Description="Total classifications with counts (including latest)">\n')
+    vcf_file.write('##INFO=<ID=HGVS,Number=.,Type=String,Description="HGVS annotations">\n')
     vcf_file.write("#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n")
 
     # Write VCF data
-    for index_ignored, row in merged_df.iterrows():
-        # Handle possible missing Other_Classifications
-        other_oncogenicity = (
-            row['Other_Classifications']
-            if pd.notnull(row['Other_Classifications']) else '.'
-        )
+    for _, row in aggregated_df.iterrows():
         info_field = (
-            f"EG_LC={row['oncogenicity_classification']};"
-            f"EG_LCD={row['date_last_evaluated'].strftime('%Y-%m-%d')};"
-            f"EG_LCS={row['specimen_id']};"
-            f"EG_OC={other_oncogenicity};"
-            f"EG_HGVS={row['hgvsc']}"
+            f"LC={row['latest_classification']};"
+            f"LCD={row['latest_date'].strftime('%Y-%m-%d')};"
+            f"LCS={row['latest_sample_id']};"
+            f"TC={row['total_classifications']};"  # Changed OC to TC
+            f"HGVS={row['hgvs']}"
         )
         vcf_file.write(
-            f"{row['chromosome']}\t{row['start']}\t{row['local_id']}\t"
+            f"{row['chromosome']}\t{row['start']}\t.\t"
             f"{row['reference_allele']}\t{row['alternate_allele']}\t.\t.\t{info_field}\n"
         )
 
-# Output this message on terminal
 print(f"VCF file created as '{output_filename}'")

--- a/create_vcf_from_inca_csv.py
+++ b/create_vcf_from_inca_csv.py
@@ -19,7 +19,7 @@ df = pd.read_csv(args.filename, parse_dates=['date_last_evaluated'], low_memory=
 timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
 
 # Create a descriptive filename
-output_filename = f"haemonc_annotation_VCF{timestamp}.vcf"
+output_filename = f"haemonc_annotation_VCF_{timestamp}.vcf"
 
 
 # Remove spaces and clean fields
@@ -43,8 +43,19 @@ other_df = df_sorted[~df_sorted['is_latest']].drop(columns='is_latest')
 
 
 # Aggregate other oncogenicity classifications with counts
-def format_oncogenicity_counts(occurence):
-    counts = occurence.value_counts()
+def format_oncogenicity_counts(classifications):
+    """
+    Format oncogenicity classifications with their counts.
+    This function takes a series of oncogenicity classifications,
+    counts the occurances of each classification formats them as:
+    classification(count)|other_classification(count)
+    Args:
+        classifications: Series of oncogenicity classifications.
+    Returns:
+        Formatted string of classification with counts, joined
+        by the '|' character
+    """
+    counts = classifications.value_counts()
     formatted_counts = [f"{classification}({count})" for classification, count in counts.items()]
     return "|".join(formatted_counts)
 


### PR DESCRIPTION
added the create_vcf_from_inca_csv.py script that enables the user to create an annotation VCF from the CSV export of the Inca database.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new Python script that transforms CSV genomic data into standard VCF output, incorporating data cleaning, sorting, and aggregation.
- **Documentation**
  - Updated the documentation with a usage example and command instructions to help users run the new script.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->